### PR TITLE
Mapping  roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,4 @@ Original Version Maintainer
 Multiple IDP Version Maintainers
 * Angel Alvarado 
 * Pablo Tapia
+* Erodis Pérez Michel(Mapping roles from idp to local)

--- a/includes/simplesamlphp_auth.drupal.inc
+++ b/includes/simplesamlphp_auth.drupal.inc
@@ -207,7 +207,7 @@ class SimpleSAML_Drupal {
         if (NULL !== $this->_simplesaml_auth_simple) {
             return $this->_simplesaml_auth_simple;
         } // end if
-        return;
+        return NULL;
     }
 
     /**
@@ -218,7 +218,7 @@ class SimpleSAML_Drupal {
         if (!empty($this->_simplesaml_auth_version)) {
             return $this->_simplesaml_auth_version;
         } // end if
-        return;
+        return NULL;
     }
 
     /**

--- a/includes/simplesamlphp_auth.drupal.inc
+++ b/includes/simplesamlphp_auth.drupal.inc
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Object to handle SAML features from within the Drupal context, this object does not pretend
  * to replace the simplesaml library, it just defines and centralizes the behavior of SAML
@@ -11,258 +12,256 @@
  * @version 1.0
  */
 class SimpleSAML_Drupal {
-	/**
-	 * Contains the reference to the SimpleSAML object
-	 * @var object SimpleSAML_Auth_Simple
-	 */
-	private $_simplesaml_auth_simple = NULL;
-	/**
-	 * A collection of data with the attributes of the IDP, the difference
-	 * between this and auth_source is that the attributes loaded here come
-	 * directly from the assertion.
-	 * @var stdClass
-	 */
-	private $_simplesaml_auth_attributes = NULL;
-	/**
-	 * Reference to the object that controls the SimpleSAML configurations
-	 * @var object SimpleSAML_Configuration
-	 */
+
+    /**
+     * Contains the reference to the SimpleSAML object
+     * @var object SimpleSAML_Auth_Simple
+     */
+    private $_simplesaml_auth_simple = NULL;
+
+    /**
+     * A collection of data with the attributes of the IDP, the difference
+     * between this and auth_source is that the attributes loaded here come
+     * directly from the assertion.
+     * @var stdClass
+     */
+    private $_simplesaml_auth_attributes = NULL;
+
+    /**
+     * Reference to the object that controls the SimpleSAML configurations
+     * @var object SimpleSAML_Configuration
+     */
     private $_simplesaml_auth_config = NULL;
-	/**
-	 * The version of the current SimpleSAML object been used
-	 * @var int
-	 */
-	private $_simplesaml_auth_version = '';
-	/**
-	 * The IDP currently been used with the attributes declared on the Drupal
-	 * Admin interface, we use this attributes to map them to the loaded attributes
-	 * coming from the assertion.
-	 * @var object stdClass
-	 */
-	private $_simplesaml_auth_source = NULL;
 
-	/**
-	 * Initializes the instance
-	 */
-	public function __construct() {
-		$this->_autoload();
-	}
-	/**
-	 * Pre-loads the object with the necessary data that will be used
-	 * to execute all SAML related tasks
-	 */
-	private function _autoload() {
-		 if ($this->_isEnabled() !== TRUE) {
-			 throw new Exception("We're sorry but the simplesaml module is not yet enabled.");
-  		 } // end if
+    /**
+     * The version of the current SimpleSAML object been used
+     * @var int
+     */
+    private $_simplesaml_auth_version = '';
 
-		 /**
-		  * Load the simplesaml Library from the specified path, if none is provided by default
-		  * the system will use '/var/simplesamlphp'
-		  */
-  		 $basedir = variable_get('simplesamlphp_auth_installdir', '/var/simplesamlphp');
-		 if (!file_exists($basedir . '/lib/_autoload.php')) {
-			   throw new Exception("Unable to continue the SAML authentication process the provided path {$basedir} is wrong.");
-  		 } // end if
+    /**
+     * The IDP currently been used with the attributes declared on the Drupal
+     * Admin interface, we use this attributes to map them to the loaded attributes
+     * coming from the assertion.
+     * @var object stdClass
+     */
+    private $_simplesaml_auth_source = NULL;
 
-		 require_once $basedir . '/lib/_autoload.php';
-  		 $this->_simplesaml_auth_config = SimpleSAML_Configuration::getInstance();
-  		 $this->_simplesaml_auth_version = $this->_simplesaml_auth_config->getVersion();
-	}
+    /**
+     * Initializes the instance
+     */
+    public function __construct() {
+        $this->_autoload();
+    }
 
-	/**
-	 * Determines if the simplesaml module / service is active on Drupal
-	 * @param bool $watchdog - Flag that is used to decide if the fail message should go to the watchdog,
-	 * default to TRUE
-	 * @return bool TRUE if enabled otherwise FALSE
-	 */
-	private function _isEnabled($watchdog = TRUE) {
-		$failure = NULL;
-  		$isActivated = variable_get('simplesamlphp_auth_activate');
-  		$basedir = variable_get('simplesamlphp_auth_installdir', '/var/simplesamlphp');
-  		if ($isActivated) {
-    		// Make sure we know where SimpleSAMLphp is.
-    		if (!file_exists($basedir)) {
-				if ($watchdog === TRUE) {
-					watchdog('simplesamlphp_auth', 'SimpleSAMLphp could not be found at %basedir . The simplesamlphp_auth module
-						cannot function until the path to the local SimpleSAMLphp instance is configured.',
-						array('%basedir' => $basedir), WATCHDOG_WARNING);
-				} // end if
-				return FALSE;
-    		} // end if
-			return TRUE;
-  		}
-		else {
-			if ($watchdog === TRUE) {
-				watchdog('simplesamlphp_auth', 'SimpleSAMLphp is not active. The simplesamlphp_auth module
+    /**
+     * Pre-loads the object with the necessary data that will be used
+     * to execute all SAML related tasks
+     */
+    private function _autoload() {
+        if ($this->_isEnabled() !== TRUE) {
+            throw new Exception("We're sorry but the simplesaml module is not yet enabled.");
+        } // end if
+
+        /**
+         * Load the simplesaml Library from the specified path, if none is provided by default
+         * the system will use '/var/simplesamlphp'
+         */
+        $basedir = variable_get('simplesamlphp_auth_installdir', '/var/simplesamlphp');
+        if (!file_exists($basedir . '/lib/_autoload.php')) {
+            throw new Exception("Unable to continue the SAML authentication process the provided path {$basedir} is wrong.");
+        } // end if
+
+        require_once $basedir . '/lib/_autoload.php';
+        $this->_simplesaml_auth_config = SimpleSAML_Configuration::getInstance();
+        $this->_simplesaml_auth_version = $this->_simplesaml_auth_config->getVersion();
+    }
+
+    /**
+     * Determines if the simplesaml module / service is active on Drupal
+     * @param bool $watchdog - Flag that is used to decide if the fail message should go to the watchdog,
+     * default to TRUE
+     * @return bool TRUE if enabled otherwise FALSE
+     */
+    private function _isEnabled($watchdog = TRUE) {
+        $failure = NULL;
+        $isActivated = variable_get('simplesamlphp_auth_activate');
+        $basedir = variable_get('simplesamlphp_auth_installdir', '/var/simplesamlphp');
+        if ($isActivated) {
+            // Make sure we know where SimpleSAMLphp is.
+            if (!file_exists($basedir)) {
+                if ($watchdog === TRUE) {
+                    watchdog('simplesamlphp_auth', 'SimpleSAMLphp could not be found at %basedir . The simplesamlphp_auth module
+						cannot function until the path to the local SimpleSAMLphp instance is configured.', array('%basedir' => $basedir), WATCHDOG_WARNING);
+                } // end if
+                return FALSE;
+            } // end if
+            return TRUE;
+        } else {
+            if ($watchdog === TRUE) {
+                watchdog('simplesamlphp_auth', 'SimpleSAMLphp is not active. The simplesamlphp_auth module
 						cannot function until is activated, enabling the module is not enough.', NULL, WATCHDOG_WARNING);
-			} // end if
-			return FALSE;
-		} // end if - else
-		return FALSE;
-	}
+            } // end if
+            return FALSE;
+        } // end if - else
+        return FALSE;
+    }
 
-	/**
-	 * Loads simpleSAMLphp IDP configuration and metadata, we retrieve the data from the
-	 * parameter of the URL (e.g saml_login/%id) the hook menu gets the data and queries
-	 * the DB to get the IDP information that's later turn into an object that we can
-	 * easy manipulate. If no IDP value is given the method will load the default SP
-	 * @see simplesamlphp_auth.module - ssaml_auth_load
-	 * @param stdClass $idp - A standard class object with the data of the IDP to load
-	 * @return object
-	 * @throws Exception When there's not a valid source to use
-	 */
-	public function load($idp = NULL) {
-		 if (NULL !== $idp && !empty($idp)) {
-			 if (is_object($idp)) {
-				$this->_simplesaml_auth_source = $idp;
-			 }
-			 else {
-				 $data = db_query("SELECT * FROM {saml_idp_settings} WHERE id = :id", array(':id' => $idp))->fetchObject();
-				 $this->_simplesaml_auth_source = $data;
-			 } // end if - else
-			 if (!empty($this->_simplesaml_auth_source)) {
-				 /**
-			  	  * Since the object will be lost once the user goes to the IDP, we need a way to remember it without
-			  	  * overwriting the values because of multiple users, best case create a COOKIE to get this done, why?
-			  	  * because is local and per user, besides it's temporary once the user is logged it'll die
-			  	  */
-			 	  setcookie('MyIDP', (string) $this->_simplesaml_auth_source->id, time() + (60 * 60));
-			 	  $attributes = unserialize($this->_simplesaml_auth_source->attributes);
-			 	  foreach ($attributes as $key => $data) {
-					   if ($key == 'cs_fields') {
-						   foreach ($data as $additional_data) {
-							   $additional_data = explode(':', $additional_data);
-							   $this->_simplesaml_auth_source->{$additional_data[0]} = $additional_data[1];
-						   } // end foreach
-      			 	   } // end if
-				 	   $this->_simplesaml_auth_source->{$key} = $data;
-    		 	  } // end foreach
-			 	  $sp_name = $this->_simplesaml_auth_source->source_name;
-			 }
-			 else {
-				 throw new Exception("Unable to continue with SSO process, there's no source available to proceed!");
-			 } // end if - else
-  		  }
-		  elseif (isset($_COOKIE['MyIDP']) && (int) $_COOKIE['MyIDP'] > 0) {
-				// Recursive call
-				return $this->load($_COOKIE['MyIDP']);
-  		  }
-		  else {
-			$sp_name = 'default-sp';
-		  } // end if - elseif - else
+    /**
+     * Loads simpleSAMLphp IDP configuration and metadata, we retrieve the data from the
+     * parameter of the URL (e.g saml_login/%id) the hook menu gets the data and queries
+     * the DB to get the IDP information that's later turn into an object that we can
+     * easy manipulate. If no IDP value is given the method will load the default SP
+     * @see simplesamlphp_auth.module - ssaml_auth_load
+     * @param stdClass $idp - A standard class object with the data of the IDP to load
+     * @return object
+     * @throws Exception When there's not a valid source to use
+     */
+    public function load($idp = NULL) {
+        if (NULL !== $idp && !empty($idp)) {
+            if (is_object($idp)) {
+                $this->_simplesaml_auth_source = $idp;
+            } else {
+                $data = db_query("SELECT * FROM {saml_idp_settings} WHERE id = :id", array(':id' => $idp))->fetchObject();
+                $this->_simplesaml_auth_source = $data;
+            } // end if - else
+            if (!empty($this->_simplesaml_auth_source)) {
+                /**
+                 * Since the object will be lost once the user goes to the IDP, we need a way to remember it without
+                 * overwriting the values because of multiple users, best case create a COOKIE to get this done, why?
+                 * because is local and per user, besides it's temporary once the user is logged it'll die
+                 */
+                setcookie('MyIDP', (string) $this->_simplesaml_auth_source->id, time() + (60 * 60));
+                $attributes = unserialize($this->_simplesaml_auth_source->attributes);
+                foreach ($attributes as $key => $data) {
+                    if ($key == 'cs_fields') {
+                        foreach ($data as $additional_data) {
+                            $additional_data = explode(':', $additional_data);
+                            $this->_simplesaml_auth_source->{$additional_data[0]} = $additional_data[1];
+                        } // end foreach
+                    } // end if
+                    $this->_simplesaml_auth_source->{$key} = $data;
+                } // end foreach
+                $sp_name = $this->_simplesaml_auth_source->source_name;
+            } else {
+                throw new Exception("Unable to continue with SSO process, there's no source available to proceed!");
+            } // end if - else
+        } elseif (isset($_COOKIE['MyIDP']) && (int) $_COOKIE['MyIDP'] > 0) {
+            // Recursive call
+            return $this->load($_COOKIE['MyIDP']);
+        } else {
+            $sp_name = 'default-sp';
+        } // end if - elseif - else
 
-  		  $this->_simplesaml_auth_simple = new SimpleSAML_Auth_Simple($sp_name);
-  		  $this->_simplesaml_auth_attributes = $this->_simplesaml_auth_simple->getAttributes();
-	}
+        $this->_simplesaml_auth_simple = new SimpleSAML_Auth_Simple($sp_name);
+        $this->_simplesaml_auth_attributes = $this->_simplesaml_auth_simple->getAttributes();
+    }
 
-	/**
-	 * Retrieves the specified attribute from the current SAML Assertion
-	 * most of the time this will be used to retrieve the mandatory attributes that
-	 * allow us to create or log the users into the system, if no attribute name is provided
-	 * the method will return all the attributes
-	 * @param string $attr_name - The requested attribute name
-	 * @return mixed - A string with the requested value OR all the attributes from the Assertion OR
-	 * an empty string when there's no attributes for the current user.
-	 * @throws Exception When the specified attribute doesn't exists for the user
-	 */
-	public function getAttrsFromAssertion($attr_name = '') {
-		if (empty($this->_simplesaml_auth_attributes)) {
-			return '';
-		} // end if
-		$attribute_assertion = '';
-		// Check if valid local session exists ..
-		if ($this->_simplesaml_auth_simple->isAuthenticated()) {
-			if (empty($attr_name)) {
-				return $this->_simplesaml_auth_attributes;
-			} // end if
-			if (isset($this->_simplesaml_auth_attributes[$attr_name])) {
-				$attribute_assertion = $this->_simplesaml_auth_attributes[$attr_name][0];
-			}
-			else {
-				throw new Exception("Error in simplesamlphp_auth.module: The requested attribute {$attr_name} doesn't exists in the assertion");
-			} // end if - else
-		} // end if
-		return $attribute_assertion;
-	}
+    /**
+     * Retrieves the specified attribute from the current SAML Assertion
+     * most of the time this will be used to retrieve the mandatory attributes that
+     * allow us to create or log the users into the system, if no attribute name is provided
+     * the method will return all the attributes
+     * @param string $attr_name - The requested attribute name
+     * @return mixed - A string with the requested value OR all the attributes from the Assertion OR
+     * an empty string when there's no attributes for the current user.
+     * @throws Exception When the specified attribute doesn't exists for the user
+     */
+    public function getAttrsFromAssertion($attr_name = '') {
+        if (empty($this->_simplesaml_auth_attributes)) {
+            return '';
+        } // end if
+        $attribute_assertion = '';
+        // Check if valid local session exists ..
+        if ($this->_simplesaml_auth_simple->isAuthenticated()) {
+            if (empty($attr_name)) {
+                return $this->_simplesaml_auth_attributes;
+            } // end if
+            if (isset($this->_simplesaml_auth_attributes[$attr_name])) {
+                $attribute_assertion = $this->_simplesaml_auth_attributes[$attr_name][0];
+            } else {
+                throw new Exception("Error in simplesamlphp_auth.module: The requested attribute {$attr_name} doesn't exists in the assertion");
+            } // end if - else
+        } // end if
+        return $attribute_assertion;
+    }
 
-	/**
-	 * Retrieves the attributes declared on the Drupal site for the corresponding IDP
-	 * @return stdClass With the properties loaded if the object exists ELSE void
-	 */
-	public function getAuthSourceAttributes() {
-		if (NULL !== $this->_simplesaml_auth_source) {
-			return $this->_simplesaml_auth_source;
-		} // end if
-		return;
-	}
+    /**
+     * Retrieves the attributes declared on the Drupal site for the corresponding IDP
+     * @return stdClass With the properties loaded if the object exists ELSE void
+     */
+    public function getAuthSourceAttributes() {
+        if (NULL !== $this->_simplesaml_auth_source) {
+            return $this->_simplesaml_auth_source;
+        } // end if
+        return NULL;
+    }
 
-	/**
-	 * Retrieves the SimpleSAML_Auth_Simple instance from the current object
-	 * this way we can use the object from outside without wrapping the simple SAML methods
-	 * from inside this object.
-	 * @return SimpleSAML_Auth_Simple object if exists ELSE void
-	 */
-	public function getSimpleSAMLAuthSimple() {
-		if (NULL !== $this->_simplesaml_auth_simple) {
-			return $this->_simplesaml_auth_simple;
-		} // end if
-		return;
-	}
+    /**
+     * Retrieves the SimpleSAML_Auth_Simple instance from the current object
+     * this way we can use the object from outside without wrapping the simple SAML methods
+     * from inside this object.
+     * @return SimpleSAML_Auth_Simple object if exists ELSE void
+     */
+    public function getSimpleSAMLAuthSimple() {
+        if (NULL !== $this->_simplesaml_auth_simple) {
+            return $this->_simplesaml_auth_simple;
+        } // end if
+        return;
+    }
 
-	/**
-	 * Retrieves the version of the library currently used
-	 * @return string Indicating the version used at the moment, IF empty void is returned
-	 */
-	public function getSimpleSAMLVersion() {
-		if (!empty($this->_simplesaml_auth_version)) {
-			return $this->_simplesaml_auth_version;
-		} // end if
-		return;
-	}
+    /**
+     * Retrieves the version of the library currently used
+     * @return string Indicating the version used at the moment, IF empty void is returned
+     */
+    public function getSimpleSAMLVersion() {
+        if (!empty($this->_simplesaml_auth_version)) {
+            return $this->_simplesaml_auth_version;
+        } // end if
+        return;
+    }
 
-	/**
-	 * Validates that everything that needs to be loaded is, before making any SAML requests
-	 * @param bool $watchdog - Keep track of function validation on watchdog, defaults to TRUE
-	 * @return bool TRUE if everything is loaded correctly, FALSE otherwise
-	 */
-	public function doSanitizeChecking($watchdog = TRUE) {
-		$config_store_type = $this->_simplesaml_auth_config->getValue('store.type');
-		// Make sure phpsession is NOT being used.
-  		if ($config_store_type == 'phpsession') {
-			  if ($watchdog === TRUE) {
-				  watchdog('simplesamlphp_auth', 'A user attempted to login using simplesamlphp but the store.type is phpsession,
+    /**
+     * Validates that everything that needs to be loaded is, before making any SAML requests
+     * @param bool $watchdog - Keep track of function validation on watchdog, defaults to TRUE
+     * @return bool TRUE if everything is loaded correctly, FALSE otherwise
+     */
+    public function doSanitizeChecking($watchdog = TRUE) {
+        $config_store_type = $this->_simplesaml_auth_config->getValue('store.type');
+        // Make sure phpsession is NOT being used.
+        if ($config_store_type == 'phpsession') {
+            if ($watchdog === TRUE) {
+                watchdog('simplesamlphp_auth', 'A user attempted to login using simplesamlphp but the store.type is phpsession,
 					use memcache or sql for simplesamlphp session storage. See: simplesamlphp/config/config.php.', NULL, WATCHDOG_WARNING);
-			  } // end if
-			  return FALSE;
-  		} // end if
+            } // end if
+            return FALSE;
+        } // end if
+        // Make sure there is an instance of SimpleSAML_Auth_Simple.
+        if (NULL === $this->_simplesaml_auth_simple) {
+            if ($watchdog === TRUE) {
+                watchdog('simplesamlphp_auth', 'A user attempted to login using this module but there was a problem.', NULL, WATCHDOG_WARNING);
+            } // end if
+            return FALSE;
+        } // end if
+        return TRUE;
+    }
 
-  		// Make sure there is an instance of SimpleSAML_Auth_Simple.
-  		if (NULL === $this->_simplesaml_auth_simple) {
-			  if ($watchdog === TRUE) {
-				  watchdog('simplesamlphp_auth', 'A user attempted to login using this module but there was a problem.',
-					  NULL, WATCHDOG_WARNING);
-			  } // end if
-			  return FALSE;
-  		} // end if
-		return TRUE;
-	}
+    /**
+     * Implements a variation of the factory method pattern that allow us to create
+     * single instances of an object without having the disadvantages of the Singleton
+     * pattern, it also help us to make sure we keep the values of the current IDP during the
+     * script execution, this is an alternative to using global variables on the
+     * simplesamlphp module.
+     * @link https://en.wikipedia.org/wiki/Factory_method_pattern
+     * @link http://ttmm.io/tech/singleton-alternative/
+     * @return SimpleSAML_Drupal object
+     */
+    public static function factory() {
+        static $instance = NULL;
+        if (NULL === $instance) {
+            $instance = new self;
+        } // end if
+        return $instance;
+    }
 
-	/**
-	 * Implements a variation of the factory method pattern that allow us to create
-	 * single instances of an object without having the disadvantages of the Singleton
-	 * pattern, it also help us to make sure we keep the values of the current IDP during the
-	 * script execution, this is an alternative to using global variables on the
-	 * simplesamlphp module.
-	 * @link https://en.wikipedia.org/wiki/Factory_method_pattern
-	 * @link http://ttmm.io/tech/singleton-alternative/
-	 * @return SimpleSAML_Drupal object
-	 */
-	public static function factory() {
-		static $instance = NULL;
-		if (NULL === $instance) {
-			$instance = new self;
-		} // end if
-		return $instance;
-	}
 }

--- a/simplesamlphp_auth.admin.inc
+++ b/simplesamlphp_auth.admin.inc
@@ -77,13 +77,15 @@ function simplesamlphp_auth_settings() {
     '#title' => t('Register users (i.e., auto-provisioning)'),
     '#default_value' => variable_get('simplesamlphp_auth_registerusers', TRUE),
     '#description' => t("Determines wether or not the module should automatically create/register new Drupal accounts for users that authenticate using SimpleSAMLphp. Unless you've done some custom work to provision Drupal accounts with the necessary authmap entries you will want this checked. NOTE: If unchecked each user must already have been provisioned a Drupal account with an appropriate entry in the authmap table before logging in. Otherwise they will receive a notice and be denied access. Be aware that simply creating a Drupal account will not create the necessary entry in the authmap table."),
-  );
+  );  
+   
   $form['simplesamlphp_auth_grp_auth'] = array(
     '#type' => 'fieldset',
     '#title' => t('Drupal Authentication'),
     '#collapsible' => TRUE,
     '#collapsed' => TRUE,
   );
+  
   $form['simplesamlphp_auth_grp_auth']['simplesamlphp_auth_allowsetdrupalpwd'] = array(
     '#type' => 'checkbox',
     '#title' => t('Allow SAML users to set Drupal passwords.'),
@@ -152,7 +154,7 @@ function simplesamlphp_auth_idp_settings() {
   $output = array(
     'introduction' => array(
       '#markup' => '<p>The following table contains the active IDP domains on the system.</p>'
-    ),
+    ),      
     'table'   => array(
       '#theme'  => 'table',
       '#header' => array(
@@ -198,6 +200,8 @@ function _simplesamlphp_auth_idp_rows() {
  * @see ssaml_auth_load
  */
 function simplesamlphp_auth_form($form, &$form_state, $idp = NULL) {
+    
+  
   $form['simplesamlphp_auth_grp_user'] = array(
     '#type' => 'fieldset',
     '#title' => (NULL !== $idp && !empty($idp->id)) ? t('Edit IDP Settings') : t('Register new IDP Domain'),
@@ -253,12 +257,48 @@ function simplesamlphp_auth_form($form, &$form_state, $idp = NULL) {
     '#description' => t('Example: <i>mail</i><br />If the user attribute is multivalued, the first value will be used.'),
     '#required' => TRUE,
   );
+  $form['simplesamlphp_auth_grp_user']['simplesamlphp_auth_roleattr'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Which attribute from the IDP should be used as role identifier for the user'),
+    '#default_value' => isset($attributes['roleattr']) && !empty($attributes['roleattr']) ? $attributes['roleattr'] : '',
+    '#description' => t('Example: <i>roles</i><br />If the user attribute is multivalued, the first value will be used.'),
+    '#required' => FALSE,
+  );
+ 
   $form['simplesamlphp_auth_grp_user']['simplesamlphp_auth_csfields'] = array(
     '#type' => 'textarea',
     '#title' => t('Additional attributes'),
     '#default_value' => isset($attributes['cs_fields']) && !empty($attributes['cs_fields']) ? implode('|', $attributes['cs_fields']) : '',
     '#description' => t('A pipe separated list of attributes that would map to custom fields.<br />Example: <i>CustomField:SAMLattr|CustomField:SAMLattr...</i> <br />For instance: <i>firstname:userName|companyname:company</i>'),
   );
+  
+  // ROLE MAPPING OPTIONS  
+  $form['simplesamlphp_auth_grp_user']['simplesamlphp_auth_syncroles'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('<strong>Sync roles</strong>'),
+    '#default_value' => isset($attributes['syncroles']) && !empty($attributes['syncroles']) ? $attributes['syncroles'] : FALSE,
+    '#description' => t('<p>Auto-sync. The role of the Drupal user account will be synchronized with the data provided by the IdP.</p><p>Review the Mapping section.</p>'),
+    '#required' => FALSE
+  );
+ 
+  $form['simplesamlphp_auth_grp_user']['simplesamlphp_auth_role_mapping'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('ROLE MAPPING')
+  );
+
+  $form['simplesamlphp_auth_grp_user']['simplesamlphp_auth_role_mapping']['info'] = array(
+    '#markup' => t('<p>The IdP can use it\'s own roles. Set in this section the mapping between IdP and Drupal roles. Accepts multiple valued comma separated.</p>')
+  );
+
+  $form['simplesamlphp_auth_grp_user']['simplesamlphp_auth_role_mapping']['simplesamlphp_auth_role_mapping_administrator'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Administrator'),
+    '#default_value' => isset($attributes['rolemappattr']) && !empty($attributes['rolemappattr']) ? $attributes['rolemappattr'] : '',
+    '#required' => FALSE,
+    '#description' => t('Example: admin,owner,superuser.')
+  );
+  // ROLE MAPPING OPTIONS
+  
   $form['actions'] = array('#type' => 'actions');
   $form['simplesamlphp_auth_grp_user']['actions']['submit'] = array(
     '#type' => 'submit',
@@ -298,13 +338,16 @@ function simplesamlphp_auth_form_submit($form, &$form_state) {
     'username' => $form_state['values']['simplesamlphp_auth_user_name'],
     'unique_id' => $form_state['values']['simplesamlphp_auth_unique_id'],
     'mailattr' => $form_state['values']['simplesamlphp_auth_mailattr'],
+    'roleattr' => $form_state['values']['simplesamlphp_auth_roleattr'],    
+    'syncroles' => $form_state['values']['simplesamlphp_auth_syncroles'],
+    'rolemappattr' => $form_state['values']['simplesamlphp_auth_role_mapping_administrator'],
   );
   /**
    * Custome attributes are not mandatory
    */
   if (!empty( $form_state['values']['simplesamlphp_auth_csfields'])) {
     $attributes['cs_fields'] = explode('|', $form_state['values']['simplesamlphp_auth_csfields']);
-  } // end if
+  } // end if 
   $data['attributes'] = serialize($attributes);
   try {
     if (isset( $form_state['values']['simplesamlphp_auth_idp_id'] ) && (int) $form_state['values']['simplesamlphp_auth_idp_id'] > 0) {
@@ -355,6 +398,11 @@ function simplesamlphp_auth_form_validate($form, &$form_state) {
     if(!empty($check_domain)) {
       form_set_error('simplesamlphp_auth_domain', t('This domain name is already active on the system, please try a different one.'));
     } // end if
+    
+    if($form_state['values']['simplesamlphp_auth_syncroles'] && empty($form_state['values']['simplesamlphp_auth_role_mapping_administrator'])){
+        form_set_error('simplesamlphp_auth_role_mapping_administrator', t('Auto-sync field is checked, This field can not be empty.'));
+    }
+    
   } // end if
 }
 /**

--- a/simplesamlphp_auth.api.php
+++ b/simplesamlphp_auth.api.php
@@ -17,76 +17,16 @@
  *   by the role evaluation process, in the format array($rid => $rid)
  */
 function hook_simplesamlphp_auth_user_roles_alter(&$roles) {
-    watchdog('simplesamlphp_auth', "Altering user roles");
+    global $_simplesamlphp_auth_saml_attributes;
+    if (isset($_simplesamlphp_auth_saml_attributes['roles'])) {
+        // The roles provided by the IdP.
+        $sso_roles = $_simplesamlphp_auth_saml_attributes['roles'];
 
-    // Get an instance of SimpleSAML_Drupal
-    try {
+        // Match role names in the saml attributes to local role names.
+        $user_roles = array_intersect(user_roles(), $sso_roles);
 
-        $simplesamlphp_drupal = SimpleSAML_Drupal::factory();
-        $simplesamlphp_auth_as = $simplesamlphp_drupal->getSimpleSAMLAuthSimple();
-
-        // Get SAML attributes
-        $attrs = $simplesamlphp_auth_as->getAttributes();
-        $simplesamlphp_authsource = $simplesamlphp_drupal->getAuthSourceAttributes();
-
-        $syncroles = $simplesamlphp_authsource->syncroles;
-
-
-        if ($syncroles) {
-            // The roles provided by the IdP.
-            $roleMapping = $simplesamlphp_authsource->roleattr;
-
-            if (!empty($roleMapping) && isset($attrs[$roleMapping]) && !empty($attrs[$roleMapping])) {
-                $adminsRole = explode(',', $simplesamlphp_authsource->rolemappattr);
-                $administrator = user_role_load_by_name('administrator');
-                $adminWeight = $administrator->rid;
-                // Match role names in the saml attributes to local role names.
-                $roleWeight = 0;
-                foreach ($attrs[$roleMapping] as $samlRole) {
-                    $samlRole = trim($samlRole);
-                    if (empty($samlRole)) {
-                        break;
-                    } else if (in_array($samlRole, $adminsRole)) {
-                        if ($roleWeight < $adminWeight) {
-                            $roleWeight = $adminWeight;
-                        }
-                        break;
-                    } else {
-                        if ($loadedRole = user_role_load_by_name($samlRole)) {
-                            $roles[$loadedRole->rid] = $loadedRole->name;
-                        }
-                    }
-                }
-                switch ($roleWeight) {
-                    // case 5:
-                    //   $roles = array(5 => 'customrole');
-                    //   break;
-                    case $adminWeight:
-                        $roles[$adminWeight] = 'administrator';
-                        break;
-                    case DRUPAL_AUTHENTICATED_RID: // default value => 2
-                    default:
-                        $roles[DRUPAL_AUTHENTICATED_RID] = 'authenticated user';
-                        break;
-                }
-            }
-        } else {
-            $roles[DRUPAL_AUTHENTICATED_RID] = 'authenticated user';
+        foreach (array_keys($user_roles) as $rid) {
+            $roles[$rid] = $rid;
         }
-    } catch (Exception $e) {
-        watchdog_exception('simplesamlphp_auth', $e);
-    } // end try - catch  
-    /*
-     * global $_simplesamlphp_auth_saml_attributes; 
-      if (isset($_simplesamlphp_auth_saml_attributes['roles'])) {
-      // The roles provided by the IdP.
-      $sso_roles = $_simplesamlphp_auth_saml_attributes['roles'];
-
-      // Match role names in the saml attributes to local role names.
-      $user_roles = array_intersect(user_roles(), $sso_roles);
-
-      foreach (array_keys($user_roles) as $rid) {
-      $roles[$rid] = $rid;
-      }
-      } */
+    }
 }

--- a/simplesamlphp_auth.api.php
+++ b/simplesamlphp_auth.api.php
@@ -16,7 +16,8 @@
  *   The roles that have been selected for the current user
  *   by the role evaluation process, in the format array($rid => $rid)
  */
-function hook_simplesamlphp_auth_user_roles_alter(&$roles) {    
+function hook_simplesamlphp_auth_user_roles_alter(&$roles) {
+    watchdog('simplesamlphp_auth', "Altering user roles");
 
     // Get an instance of SimpleSAML_Drupal
     try {
@@ -27,57 +28,54 @@ function hook_simplesamlphp_auth_user_roles_alter(&$roles) {
         // Get SAML attributes
         $attrs = $simplesamlphp_auth_as->getAttributes();
         $simplesamlphp_authsource = $simplesamlphp_drupal->getAuthSourceAttributes();
-    } catch (Exception $e) {
-        watchdog_exception('simplesamlphp_auth', $e);
-    } // end try - catch
-   
-    $syncroles = $simplesamlphp_drupal->getAttrsFromAssertion($simplesamlphp_authsource->syncroles);
+
+        $syncroles = $simplesamlphp_authsource->syncroles;
 
 
-    if ($syncroles) {
-        // The roles provided by the IdP.
-        $roleMapping = $simplesamlphp_drupal->getAttrsFromAssertion($simplesamlphp_authsource->roleattr);
+        if ($syncroles) {
+            // The roles provided by the IdP.
+            $roleMapping = $simplesamlphp_authsource->roleattr;
 
-        if (!empty($roleMapping) && isset($attrs[$roleMapping]) && !empty($attrs[$roleMapping])) {
-            $adminsRole = explode(',', $simplesamlphp_drupal->getAttrsFromAssertion($simplesamlphp_authsource->rolemappattr));
-            
-            $administrator = user_role_load_by_name('administrator');
-            $adminWeight = $administrator->rid;
-            // Match role names in the saml attributes to local role names.
-            $roleWeight = 0;
-            foreach ($attrs[$roleMapping] as $samlRole) {
-                $samlRole = trim($samlRole);
-                if (empty($samlRole)) {
-                    break;
-                }                
-                else if (in_array($samlRole, $adminsRole)) {
-                    if ($roleWeight < $adminWeight) {
-                        $roleWeight = $adminWeight;
-                    }
-                    break;
-                } else {
-                    if ($loadedRole = user_role_load_by_name($samlRole)) {
-                        $roles[$loadedRole->rid] = $loadedRole->name;
+            if (!empty($roleMapping) && isset($attrs[$roleMapping]) && !empty($attrs[$roleMapping])) {
+                $adminsRole = explode(',', $simplesamlphp_authsource->rolemappattr);
+                $administrator = user_role_load_by_name('administrator');
+                $adminWeight = $administrator->rid;
+                // Match role names in the saml attributes to local role names.
+                $roleWeight = 0;
+                foreach ($attrs[$roleMapping] as $samlRole) {
+                    $samlRole = trim($samlRole);
+                    if (empty($samlRole)) {
+                        break;
+                    } else if (in_array($samlRole, $adminsRole)) {
+                        if ($roleWeight < $adminWeight) {
+                            $roleWeight = $adminWeight;
+                        }
+                        break;
+                    } else {
+                        if ($loadedRole = user_role_load_by_name($samlRole)) {
+                            $roles[$loadedRole->rid] = $loadedRole->name;
+                        }
                     }
                 }
+                switch ($roleWeight) {
+                    // case 5:
+                    //   $roles = array(5 => 'customrole');
+                    //   break;
+                    case $adminWeight:
+                        $roles[$adminWeight] = 'administrator';
+                        break;
+                    case DRUPAL_AUTHENTICATED_RID: // default value => 2
+                    default:
+                        $roles[DRUPAL_AUTHENTICATED_RID] = 'authenticated user';
+                        break;
+                }
             }
-            switch ($roleWeight) {
-                // case 5:
-                //   $roles = array(5 => 'customrole');
-                //   break;
-                case $adminWeight:
-                    $roles[$adminWeight] = 'administrator';
-                    break;
-                case DRUPAL_AUTHENTICATED_RID: // default value => 2
-                default:
-                    $roles[DRUPAL_AUTHENTICATED_RID] = 'authenticated user';
-                    break;
-            }
+        } else {
+            $roles[DRUPAL_AUTHENTICATED_RID] = 'authenticated user';
         }
-    }else {        
-      $roles[DRUPAL_AUTHENTICATED_RID] = 'authenticated user';    
-    }
-
+    } catch (Exception $e) {
+        watchdog_exception('simplesamlphp_auth', $e);
+    } // end try - catch  
     /*
      * global $_simplesamlphp_auth_saml_attributes; 
       if (isset($_simplesamlphp_auth_saml_attributes['roles'])) {

--- a/simplesamlphp_auth.api.php
+++ b/simplesamlphp_auth.api.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file
  * Hooks for simpleSAMLphp Authentication module.
@@ -15,17 +16,79 @@
  *   The roles that have been selected for the current user
  *   by the role evaluation process, in the format array($rid => $rid)
  */
-function hook_simplesamlphp_auth_user_roles_alter( &$roles ) {
-  global $_simplesamlphp_auth_saml_attributes;
-  if ( isset( $_simplesamlphp_auth_saml_attributes['roles'] ) ) {
-    // The roles provided by the IdP.
-    $sso_roles = $_simplesamlphp_auth_saml_attributes['roles'];
+function hook_simplesamlphp_auth_user_roles_alter(&$roles) {    
 
-    // Match role names in the saml attributes to local role names.
-    $user_roles = array_intersect( user_roles(), $sso_roles );
+    // Get an instance of SimpleSAML_Drupal
+    try {
 
-    foreach (array_keys($user_roles) as $rid) {
-      $roles[$rid] = $rid;
+        $simplesamlphp_drupal = SimpleSAML_Drupal::factory();
+        $simplesamlphp_auth_as = $simplesamlphp_drupal->getSimpleSAMLAuthSimple();
+
+        // Get SAML attributes
+        $attrs = $simplesamlphp_auth_as->getAttributes();
+        $simplesamlphp_authsource = $simplesamlphp_drupal->getAuthSourceAttributes();
+    } catch (Exception $e) {
+        watchdog_exception('simplesamlphp_auth', $e);
+    } // end try - catch
+   
+    $syncroles = $simplesamlphp_drupal->getAttrsFromAssertion($simplesamlphp_authsource->syncroles);
+
+
+    if ($syncroles) {
+        // The roles provided by the IdP.
+        $roleMapping = $simplesamlphp_drupal->getAttrsFromAssertion($simplesamlphp_authsource->roleattr);
+
+        if (!empty($roleMapping) && isset($attrs[$roleMapping]) && !empty($attrs[$roleMapping])) {
+            $adminsRole = explode(',', $simplesamlphp_drupal->getAttrsFromAssertion($simplesamlphp_authsource->rolemappattr));
+            
+            $administrator = user_role_load_by_name('administrator');
+            $adminWeight = $administrator->rid;
+            // Match role names in the saml attributes to local role names.
+            $roleWeight = 0;
+            foreach ($attrs[$roleMapping] as $samlRole) {
+                $samlRole = trim($samlRole);
+                if (empty($samlRole)) {
+                    break;
+                }                
+                else if (in_array($samlRole, $adminsRole)) {
+                    if ($roleWeight < $adminWeight) {
+                        $roleWeight = $adminWeight;
+                    }
+                    break;
+                } else {
+                    if ($loadedRole = user_role_load_by_name($samlRole)) {
+                        $roles[$loadedRole->rid] = $loadedRole->name;
+                    }
+                }
+            }
+            switch ($roleWeight) {
+                // case 5:
+                //   $roles = array(5 => 'customrole');
+                //   break;
+                case $adminWeight:
+                    $roles[$adminWeight] = 'administrator';
+                    break;
+                case DRUPAL_AUTHENTICATED_RID: // default value => 2
+                default:
+                    $roles[DRUPAL_AUTHENTICATED_RID] = 'authenticated user';
+                    break;
+            }
+        }
+    }else {        
+      $roles[DRUPAL_AUTHENTICATED_RID] = 'authenticated user';    
     }
-  }
+
+    /*
+     * global $_simplesamlphp_auth_saml_attributes; 
+      if (isset($_simplesamlphp_auth_saml_attributes['roles'])) {
+      // The roles provided by the IdP.
+      $sso_roles = $_simplesamlphp_auth_saml_attributes['roles'];
+
+      // Match role names in the saml attributes to local role names.
+      $user_roles = array_intersect(user_roles(), $sso_roles);
+
+      foreach (array_keys($user_roles) as $rid) {
+      $roles[$rid] = $rid;
+      }
+      } */
 }

--- a/simplesamlphp_auth.inc
+++ b/simplesamlphp_auth.inc
@@ -136,7 +136,7 @@ function _simplesaml_auth_user_register($authname) {
         $userinfo = array(
           'name' => $simplesamlphp_drupal->getAttrsFromAssertion($simplesamlphp_authsource->username),
           'mail' => $simplesamlphp_drupal->getAttrsFromAssertion($simplesamlphp_authsource->mailattr),
-          'timezone' => 'America/New_York'
+          'timezone' => date_default_timezone_get(),
         );
 
         /**
@@ -148,8 +148,24 @@ function _simplesaml_auth_user_register($authname) {
          *   );
          * }
          */
-
-        $user = user_save($user, $userinfo);
+        
+        /**
+         * Populate roles 
+         */
+        
+        $roles = array();
+        // Calling all modules implementing hook_simplesamlphp_auth_user_roles_alter():
+        drupal_alter('simplesamlphp_auth_user_roles', $roles);
+        // You should implement hook_simplesamlphp_auth_user_roles_alter() in all other modules in which you want to alter $roles
+        if (!empty($roles)) {
+                try {
+                    $userinfo['roles']= $roles;
+                    
+                    $user = user_save($user, $userinfo);
+                } catch (Exception $e) {
+                    return FALSE;
+                }
+        }
         return $user;
       }
       else {

--- a/simplesamlphp_auth.inc
+++ b/simplesamlphp_auth.inc
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file
  * Contains non-hook implementations.
@@ -9,7 +10,6 @@
  * @author Pablo Tapia <pablo.orozco@ingenia.com>
  * @author Angel Alvarado <angel.angelio.ingenia@gmail.com>
  */
-
 /**
  * We load the custom Simple SAML Auth object to store all the IDP information
  */
@@ -19,65 +19,63 @@ module_load_include('inc', 'simplesamlphp_auth', 'includes/simplesamlphp_auth.dr
  * Performs login and/or register actions for SAML authenticated users.
  */
 function _simplesaml_auth_login_register() {
-  global $user;
-  try {
-    $simplesamlphp_drupal = SimpleSAML_Drupal::factory();
-    $simplesamlphp_auth_as = $simplesamlphp_drupal->getSimpleSAMLAuthSimple();
-  }
-  catch(Exception $e) {
-    watchdog_exception('simplesamlphp_auth', $e);
-  }
-  // End try - catch.
+    global $user;
+    try {
+        $simplesamlphp_drupal = SimpleSAML_Drupal::factory();
+        $simplesamlphp_auth_as = $simplesamlphp_drupal->getSimpleSAMLAuthSimple();
+    } catch (Exception $e) {
+        watchdog_exception('simplesamlphp_auth', $e);
+    }
+    // End try - catch.
 
-  /**
-   * Check if user is logged in SimpleSAMLphp (but not Drupal), if it is
-   * then start loading the SAML attributes
-   */
-  if ($simplesamlphp_auth_as->isAuthenticated()) {
-    $unique_attr = !empty($simplesamlphp_drupal->getAuthSourceAttributes()) ? $simplesamlphp_drupal->getAuthSourceAttributes()->unique_id : 'mail';
-    $unique_attr_value = $simplesamlphp_drupal->getAttrsFromAssertion($unique_attr);
-    _simplesaml_auth_debug(t('Authname is [%authname] userid is [%uid]', [
-      '%authname' => $unique_attr_value,
-      '%uid'      => $user->uid,
-    ]));
-    if (!empty($unique_attr_value)) {
-      /**
-       * User is logged in with SAML authentication and we got the unique ID
-       */
-      _simplesaml_auth_debug(t('Finding authname for ID: [%unique_attr_value]', ['%unique_attr_value' => $unique_attr_value]));
+    /**
+     * Check if user is logged in SimpleSAMLphp (but not Drupal), if it is
+     * then start loading the SAML attributes
+     */
+    if ($simplesamlphp_auth_as->isAuthenticated()) {
+        $unique_attr = !empty($simplesamlphp_drupal->getAuthSourceAttributes()) ? $simplesamlphp_drupal->getAuthSourceAttributes()->unique_id : 'mail';
+        $unique_attr_value = $simplesamlphp_drupal->getAttrsFromAssertion($unique_attr);
+        _simplesaml_auth_debug(t('Authname is [%authname] userid is [%uid]', [
+            '%authname' => $unique_attr_value,
+            '%uid' => $user->uid,
+        ]));
+        if (!empty($unique_attr_value)) {
+            /**
+             * User is logged in with SAML authentication and we got the unique ID
+             */
+            _simplesaml_auth_debug(t('Finding authname for ID: [%unique_attr_value]', ['%unique_attr_value' => $unique_attr_value]));
 
-      /**
-       * Some IDPs might use an alphanumeric unique attribute instead of the email address, mainly because the email addresses
-       * might change form time to time for those specific cases we merge the IDP unique ID with the alphanumeric attribute
-       * to make it more unique (some IdPs may have the same unique attribute!)
-       */
-      if (!valid_email_address($unique_attr_value)) {
-        $authname = $simplesamlphp_drupal->getAuthSourceAttributes()->id . '-' . $unique_attr_value;
-      }
-      else {
-        // This customer uses email address as UniqueID.
-        $authname = $unique_attr_value;
-      }
-      // End if.
+            /**
+             * Some IDPs might use an alphanumeric unique attribute instead of the email address, mainly because the email addresses
+             * might change form time to time for those specific cases we merge the IDP unique ID with the alphanumeric attribute
+             * to make it more unique (some IdPs may have the same unique attribute!)
+             */
+            if (!valid_email_address($unique_attr_value)) {
+                $authname = $simplesamlphp_drupal->getAuthSourceAttributes()->id . '-' . $unique_attr_value;
+            } else {
+                // This customer uses email address as UniqueID.
+                $authname = $unique_attr_value;
+            }
+            // End if.
 
-      /**
-       * User is logged in with SAML authentication and we got the unique
-       * identifier, so try to log into Drupal.
-       */
-      _simplesaml_auth_debug(t('Loading Drupal user [%authname]', ['%authname' => $authname]));
-      // Retrieve user mapping and attempt to log the user in.
-      $ext_user = user_external_load($authname);
+            /**
+             * User is logged in with SAML authentication and we got the unique
+             * identifier, so try to log into Drupal.
+             */
+            _simplesaml_auth_debug(t('Loading Drupal user [%authname]', ['%authname' => $authname]));
+            // Retrieve user mapping and attempt to log the user in.
+            $ext_user = user_external_load($authname);
 
-      // If we did not find a Drupal user, register a new one.
-      if (!$ext_user) {
-        $ext_user = _simplesaml_auth_user_register($authname);
-      }
-      // End if.
-      _simplesaml_auth_user_login($ext_user);
+            // If we did not find a Drupal user, register a new one.
+            if (!$ext_user) {
+                $ext_user = _simplesaml_auth_user_register($authname);
+            }
+            // End if.
+            _simplesaml_auth_user_login($ext_user);
+        }
+        // End if.
     }
     // End if.
-  }
-  // End if.
 }
 
 /**
@@ -91,101 +89,136 @@ function _simplesaml_auth_login_register() {
  *   The newly create Drupal user object.
  */
 function _simplesaml_auth_user_register($authname) {
-  global $user;
-  try {
-    $simplesamlphp_drupal = SimpleSAML_Drupal::factory();
-    $simplesamlphp_auth_as = $simplesamlphp_drupal->getSimpleSAMLAuthSimple();
-    $simplesamlphp_authsource = $simplesamlphp_drupal->getAuthSourceAttributes();
-  }
-  catch (Exception $e) {
-    watchdog_exception('simplesamlphp_auth', $e);
-  } // end try - catch
-
-  // First we check the admin settings for simpleSAMLphp and find out if we are allowed to register users.
-  if (variable_get('simplesamlphp_auth_registerusers', TRUE)) {
-    // We are allowed to register new users.
-    _simplesaml_auth_debug(t('Register [%authname]', array('%authname' => $authname)));
-
-    /**
-     * It's possible that a user with this name already exists, but is not
-     * permitted to login to Drupal via SAML. If so, log out of SAML and
-     * redirect to the front page.
-     */
-    $account = user_load_by_name($authname);
-    if ($account) {
-      _simplesaml_auth_debug(t('User [%authname] could not be registered because that username already exists and is not SAML enabled.',
-        array('%authname' => $authname)));
-      drupal_set_message(t('We are sorry, your user account is not SAML enabled.'));
-      $simplesamlphp_auth_as->logout(base_path());
-      return FALSE;
-    } // end if
-
-      // Register the new user.
-      user_external_login_register($authname, 'simplesamlphp_auth');
-      _simplesaml_auth_debug(t('Registered [%authname] with uid @uid', array(
-        '%authname' => $authname,
-        '@uid'      => $user->uid
-      )));
-
-      if (!empty($user->uid)) {
-        /**
-         * Populate roles and additional fields based on configuration settings.
-         * We don't need to retrieve data from SAML configurations the only role for these users on this part
-         * of the process is subscribers
-         */
-        $userinfo = array(
-          'name' => $simplesamlphp_drupal->getAttrsFromAssertion($simplesamlphp_authsource->username),
-          'mail' => $simplesamlphp_drupal->getAttrsFromAssertion($simplesamlphp_authsource->mailattr),
-          'timezone' => date_default_timezone_get(),
-        );
+    global $user;
+    try {
+        $simplesamlphp_drupal = SimpleSAML_Drupal::factory();
+        $simplesamlphp_auth_as = $simplesamlphp_drupal->getSimpleSAMLAuthSimple();
+        $simplesamlphp_authsource = $simplesamlphp_drupal->getAuthSourceAttributes();
+    } catch (Exception $e) {
+        watchdog_exception('simplesamlphp_auth', $e);
+    } // end try - catch
+    // First we check the admin settings for simpleSAMLphp and find out if we are allowed to register users.
+    if (variable_get('simplesamlphp_auth_registerusers', TRUE)) {
+        // We are allowed to register new users.
+        _simplesaml_auth_debug(t('Register [%authname]', array('%authname' => $authname)));
 
         /**
-         * If you want, you can place more custom fields and populate them here
-         * @example
-         * if (isset($simplesamlphp_authsource->firstname)) {
-         *   $userinfo['field_first_name'] = array(
-         *     'und' => array(array('value' => $simplesamlphp_drupal->getAttrsFromAssertion($simplesamlphp_authsource->firstname)))
-         *   );
-         * }
+         * It's possible that a user with this name already exists, but is not
+         * permitted to login to Drupal via SAML. If so, log out of SAML and
+         * redirect to the front page.
          */
-        
-        /**
-         * Populate roles 
-         */
-        
-        $roles = array();
-        // Calling all modules implementing hook_simplesamlphp_auth_user_roles_alter():
-        drupal_alter('simplesamlphp_auth_user_roles', $roles);
-        // You should implement hook_simplesamlphp_auth_user_roles_alter() in all other modules in which you want to alter $roles
-        if (!empty($roles)) {
-                try {
-                    $userinfo['roles']= $roles;
-                    
-                    $user = user_save($user, $userinfo);
-                } catch (Exception $e) {
-                    return FALSE;
+        $account = user_load_by_name($authname);
+        if ($account) {
+            _simplesaml_auth_debug(t('User [%authname] could not be registered because that username already exists and is not SAML enabled.', array('%authname' => $authname)));
+            drupal_set_message(t('We are sorry, your user account is not SAML enabled.'));
+            $simplesamlphp_auth_as->logout(base_path());
+            return FALSE;
+        } // end if
+        // Register the new user.
+        user_external_login_register($authname, 'simplesamlphp_auth');
+        _simplesaml_auth_debug(t('Registered [%authname] with uid @uid', array(
+            '%authname' => $authname,
+            '@uid' => $user->uid
+        )));
+
+        if (!empty($user->uid)) {
+            /**
+             * Populate roles and additional fields based on configuration settings.
+             * We don't need to retrieve data from SAML configurations the only role for these users on this part
+             * of the process is subscribers
+             */
+            $userinfo = array(
+                'name' => $simplesamlphp_drupal->getAttrsFromAssertion($simplesamlphp_authsource->username),
+                'mail' => $simplesamlphp_drupal->getAttrsFromAssertion($simplesamlphp_authsource->mailattr),
+                'timezone' => date_default_timezone_get(),
+            );
+
+            /**
+             * If you want, you can place more custom fields and populate them here
+             * @example
+             * if (isset($simplesamlphp_authsource->firstname)) {
+             *   $userinfo['field_first_name'] = array(
+             *     'und' => array(array('value' => $simplesamlphp_drupal->getAttrsFromAssertion($simplesamlphp_authsource->firstname)))
+             *   );
+             * }
+             */
+            /**
+             * Populate roles 
+             */
+            $roles = array();
+            try {
+                // Get SAML attributes
+                $attrs = $simplesamlphp_auth_as->getAttributes();                
+
+                if ($simplesamlphp_authsource->syncroles) {
+                    // The roles provided by the IdP.
+                    $roleMapping = $simplesamlphp_authsource->roleattr;
+
+                    if (!empty($roleMapping) && isset($attrs[$roleMapping]) && !empty($attrs[$roleMapping])) {
+                        $adminsRole = explode(',', $simplesamlphp_authsource->rolemappattr);
+                        $administrator = user_role_load_by_name('administrator');
+                        $adminWeight = $administrator->rid;
+                        // Match role names in the saml attributes to local role names.
+                        $roleWeight = 0;
+                        foreach ($attrs[$roleMapping] as $samlRole) {
+                            $samlRole = trim($samlRole);
+                            if (empty($samlRole)) {
+                                break;
+                            } else if (in_array($samlRole, $adminsRole)) {
+                                if ($roleWeight < $adminWeight) {
+                                    $roleWeight = $adminWeight;
+                                }
+                                break;
+                            } else {
+                                if ($loadedRole = user_role_load_by_name($samlRole)) {
+                                    $roles[$loadedRole->rid] = $loadedRole->name;
+                                }
+                            }
+                        }
+                        switch ($roleWeight) {
+                            // case 5:
+                            //   $roles = array(5 => 'customrole');
+                            //   break;
+                            case $adminWeight:
+                                $roles[$adminWeight] = 'administrator';
+                                break;
+                            case DRUPAL_AUTHENTICATED_RID: // default value => 2
+                            default:
+                                $roles[DRUPAL_AUTHENTICATED_RID] = 'authenticated user';
+                                break;
+                        }
+                    }
+                } else {
+                    $roles[DRUPAL_AUTHENTICATED_RID] = 'authenticated user';
                 }
-        }
-        return $user;
-      }
-      else {
+            } catch (Exception $e) {
+                watchdog_exception('simplesamlphp_auth', $e);
+            }
+            // Calling all modules implementing hook_simplesamlphp_auth_user_roles_alter()
+            // You should implement hook_simplesamlphp_auth_user_roles_alter() in all other modules in which you want to alter $roles
+            drupal_alter('simplesamlphp_auth_user_roles', $roles);
+            if (!empty($roles)) {
+                $userinfo['roles'] = $roles;
+            }
+            $user = user_save($user, $userinfo);
+            return $user;
+        } else {
+            /**
+             * We were unable to register this new user on the site.
+             * We let the user know about this, log an error, and redirect to the home page.
+             */
+            drupal_set_message(t("We are sorry. While you have successfully authenticated, we were unable to create an account for you on this site. Please ask the site administrator to provision access for you."));
+            watchdog('simplesamlphp_auth', 'Unable to register %authname using simplesamlphp_auth', array('%authname' => $authname), WATCHDOG_ERROR);
+            $simplesamlphp_auth_as->logout(base_path());
+        } // end if- else
+    } else {
         /**
-         * We were unable to register this new user on the site.
-         * We let the user know about this, log an error, and redirect to the home page.
+         * We are not allowed to register new users on the site through simpleSAML.
+         * We let the user know about this and redirect to the user/login page.
          */
-        drupal_set_message(t("We are sorry. While you have successfully authenticated, we were unable to create an account for you on this site. Please ask the site administrator to provision access for you."));
-        watchdog('simplesamlphp_auth', 'Unable to register %authname using simplesamlphp_auth', array('%authname' => $authname), WATCHDOG_ERROR);
+        drupal_set_message(t("We are sorry. While you have successfully authenticated, you are not yet entitled to access this site. Please ask the site administrator to provision access for you."));
         $simplesamlphp_auth_as->logout(base_path());
-      } // end if- else
-  }
-  else {
-    /**
-     * We are not allowed to register new users on the site through simpleSAML.
-     * We let the user know about this and redirect to the user/login page.
-     */
-    drupal_set_message(t("We are sorry. While you have successfully authenticated, you are not yet entitled to access this site. Please ask the site administrator to provision access for you."));
-    $simplesamlphp_auth_as->logout(base_path());
-  } // end if - else
+    } // end if - else
 }
 
 /**
@@ -195,38 +228,36 @@ function _simplesaml_auth_user_register($authname) {
  *   The user account object to update.
  */
 function _simplesaml_auth_user_update($account) {
-  _simplesaml_auth_debug(t('Updating username [%acctname]', array('%acctname' => $account->name)));
-  try {
-    $simplesamlphp_drupal = SimpleSAML_Drupal::factory();
-    $simplesamlphp_authsource = $simplesamlphp_drupal->getAuthSourceAttributes();
-  }
-  catch (Exception $e) {
-    watchdog_exception('simplesamlphp_auth', $e);
-  } // end try - catch
+    _simplesaml_auth_debug(t('Updating username [%acctname]', array('%acctname' => $account->name)));
+    try {
+        $simplesamlphp_drupal = SimpleSAML_Drupal::factory();
+        $simplesamlphp_authsource = $simplesamlphp_drupal->getAuthSourceAttributes();
+    } catch (Exception $e) {
+        watchdog_exception('simplesamlphp_auth', $e);
+    } // end try - catch
 
-  db_update('users')
-    ->fields(array('name' => $account->name))
-    ->condition('uid', $account->uid)
-    ->execute();
-
-  // Get mail from default attribute.
-  try {
-    $mail_address = $simplesamlphp_drupal->getAttrsFromAssertion($simplesamlphp_authsource->mailattr);
-  }
-  catch (Exception $e) {
-    drupal_set_message(t('Your e-mail address was not provided by your identity provider (IDP).'), "error");
-    watchdog_exception('simplesamlphp_auth', $e);
-  } // end try - catch
-
-  _simplesaml_auth_debug(t('Updating mail [%mailaddr]', array('%mailaddr' => $mail_address)));
-
-  if (!empty($mail_address)) {
     db_update('users')
-      ->fields(array('mail' => $mail_address))
-      ->condition('uid', $account->uid)
-      ->execute();
-  }
-  // End if.
+            ->fields(array('name' => $account->name))
+            ->condition('uid', $account->uid)
+            ->execute();
+
+    // Get mail from default attribute.
+    try {
+        $mail_address = $simplesamlphp_drupal->getAttrsFromAssertion($simplesamlphp_authsource->mailattr);
+    } catch (Exception $e) {
+        drupal_set_message(t('Your e-mail address was not provided by your identity provider (IDP).'), "error");
+        watchdog_exception('simplesamlphp_auth', $e);
+    } // end try - catch
+
+    _simplesaml_auth_debug(t('Updating mail [%mailaddr]', array('%mailaddr' => $mail_address)));
+
+    if (!empty($mail_address)) {
+        db_update('users')
+                ->fields(array('mail' => $mail_address))
+                ->condition('uid', $account->uid)
+                ->execute();
+    }
+    // End if.
 }
 
 /**
@@ -241,80 +272,79 @@ function _simplesaml_auth_user_update($account) {
  *   IF success void ELSE boolean FALSE
  */
 function _simplesaml_auth_user_login($ext_user) {
-  // Making sure we use the loaded user as the current user
-  global $user;
-  $user = $ext_user;
-  try {
-    $simplesamlphp_auth_as = SimpleSAML_Drupal::factory()->getSimpleSAMLAuthSimple();
-  } catch(Exception $e) {
-    watchdog_exception('simplesamlphp_auth', $e);
-  } // end try - catch
+    // Making sure we use the loaded user as the current user
+    global $user;
+    $user = $ext_user;
+    try {
+        $simplesamlphp_auth_as = SimpleSAML_Drupal::factory()->getSimpleSAMLAuthSimple();
+    } catch (Exception $e) {
+        watchdog_exception('simplesamlphp_auth', $e);
+    } // end try - catch
 
-  /**
-   * Since the whole purpose of the COOKIE is to log the user once it's done
-   * we don't need it anymore
-   */
-  setcookie('MyIDP', '');
-  
-  /**
-   * You can execute additional logic to validate users HERE.
-   */
-   
-  // Finalizing the login, calls hook_user op login.
-  $edit = array();
-  user_login_finalize($edit);
-  return;
+    /**
+     * Since the whole purpose of the COOKIE is to log the user once it's done
+     * we don't need it anymore
+     */
+    setcookie('MyIDP', '');
+
+    /**
+     * You can execute additional logic to validate users HERE.
+     */
+    // Finalizing the login, calls hook_user op login.
+    $edit = array();
+    user_login_finalize($edit);
+    return;
 }
 
 /**
  * Denies non-SAML-authenticated access to the site for configured Drupal roles.
  */
 function simplesaml_auth_moderate_local_login() {
-  global $user;
-  $simplesamlphp_auth_as = SimpleSAML_Drupal::factory()->getSimpleSAMLAuthSimple();
+    global $user;
+    $simplesamlphp_auth_as = SimpleSAML_Drupal::factory()->getSimpleSAMLAuthSimple();
 
-  // If we forbid users from logging in using local accounts.
-  if (!variable_get('simplesamlphp_auth_allowdefaultlogin', TRUE)) {
-    // If the user has NOT been authenticated via simpleSAML...
-    if (!$simplesamlphp_auth_as->isAuthenticated()) {
-      // :FYI: Until Drupal issue #754560 is corrected this message will never be seen by the user.
-      drupal_set_message( t( "We are sorry, users are not permitted to log in using local accounts." ) );
-      // Destroy the user's session (log them out).
-      _simplesamlphp_auth_destroy_drupal_session();
-    } // end if
-  } else {
-    // If we are allowing users to log in with local accounts.
-    // If the user has NOT been authenticated via simpleSAML.
-    if (!$simplesamlphp_auth_as->isAuthenticated()) {
-      // See if we limit this privilege to specified users
-      $strAllwDefLogUsers = variable_get('simplesamlphp_auth_allowdefaultloginusers', '');
-      $arrAllwDefLogUsers = array();
-      // See if we limit this privilege to specified roles.
-      $arrAllwDefLogRoles = variable_get('simplesamlphp_auth_allowdefaultloginroles', FALSE);
-      // If user IDs or roles are specified, we let them in, but everyone else gets logged out.
-      if (drupal_strlen( $strAllwDefLogUsers ) || $arrAllwDefLogRoles) {
-        // Convert the string into an array.
-        // @todo Perform a test to make sure that only numbers, spaces, or commas are in the string.
-        $arrAllwDefLogUsers = explode(',', $strAllwDefLogUsers);
-        // If we still have something to work with.
-        if (0 < count($arrAllwDefLogUsers ) || 0 < count($arrAllwDefLogRoles)) {
-          /**
-           * Log the user out of Drupal if:
-           * 1) the current user's uid is NOT in the list of allowed uids...
-           * 2) or their role does not match and allowed mixed mode role.
-           */
-          $matchRoles = array_intersect(array_keys($user->roles), $arrAllwDefLogRoles);
-          if (!in_array($user->uid, $arrAllwDefLogUsers) && count($matchRoles) == 0) {
-            // User is logged into Drupal, but may not be logged into simpleSAML.
-            // If this is the case we're supposed to log the user out of Drupal.
+    // If we forbid users from logging in using local accounts.
+    if (!variable_get('simplesamlphp_auth_allowdefaultlogin', TRUE)) {
+        // If the user has NOT been authenticated via simpleSAML...
+        if (!$simplesamlphp_auth_as->isAuthenticated()) {
             // :FYI: Until Drupal issue #754560 is corrected this message will never be seen by the user.
-            drupal_set_message(t("We are sorry, you are not permitted to log in using a local account."));
-            // The least we can do is write something to the watchdog so someone will know what's happening.
-            watchdog('simplesamlphp_auth', 'User %name not authorized to log in using local account.', array('%name' => $user->name));
+            drupal_set_message(t("We are sorry, users are not permitted to log in using local accounts."));
+            // Destroy the user's session (log them out).
             _simplesamlphp_auth_destroy_drupal_session();
-          } // end if
         } // end if
-      } // end if
-    } // end if
-  } // end if - else
+    } else {
+        // If we are allowing users to log in with local accounts.
+        // If the user has NOT been authenticated via simpleSAML.
+        if (!$simplesamlphp_auth_as->isAuthenticated()) {
+            // See if we limit this privilege to specified users
+            $strAllwDefLogUsers = variable_get('simplesamlphp_auth_allowdefaultloginusers', '');
+            $arrAllwDefLogUsers = array();
+            // See if we limit this privilege to specified roles.
+            $arrAllwDefLogRoles = variable_get('simplesamlphp_auth_allowdefaultloginroles', FALSE);
+            // If user IDs or roles are specified, we let them in, but everyone else gets logged out.
+            if (drupal_strlen($strAllwDefLogUsers) || $arrAllwDefLogRoles) {
+                // Convert the string into an array.
+                // @todo Perform a test to make sure that only numbers, spaces, or commas are in the string.
+                $arrAllwDefLogUsers = explode(',', $strAllwDefLogUsers);
+                // If we still have something to work with.
+                if (0 < count($arrAllwDefLogUsers) || 0 < count($arrAllwDefLogRoles)) {
+                    /**
+                     * Log the user out of Drupal if:
+                     * 1) the current user's uid is NOT in the list of allowed uids...
+                     * 2) or their role does not match and allowed mixed mode role.
+                     */
+                    $matchRoles = array_intersect(array_keys($user->roles), $arrAllwDefLogRoles);
+                    if (!in_array($user->uid, $arrAllwDefLogUsers) && count($matchRoles) == 0) {
+                        // User is logged into Drupal, but may not be logged into simpleSAML.
+                        // If this is the case we're supposed to log the user out of Drupal.
+                        // :FYI: Until Drupal issue #754560 is corrected this message will never be seen by the user.
+                        drupal_set_message(t("We are sorry, you are not permitted to log in using a local account."));
+                        // The least we can do is write something to the watchdog so someone will know what's happening.
+                        watchdog('simplesamlphp_auth', 'User %name not authorized to log in using local account.', array('%name' => $user->name));
+                        _simplesamlphp_auth_destroy_drupal_session();
+                    } // end if
+                } // end if
+            } // end if
+        } // end if
+    } // end if - else
 }

--- a/simplesamlphp_auth.info
+++ b/simplesamlphp_auth.info
@@ -4,3 +4,4 @@ core = 7.x
 configure = admin/config/people/simplesamlphp_auth
 version = "7.x-4.x-dev"
 project = "simplesamlphp_auth"
+files[] = tests/simplesamlphp_auth.test

--- a/simplesamlphp_auth.info
+++ b/simplesamlphp_auth.info
@@ -1,4 +1,4 @@
-name = simpleSAMLphp authentication
+name = Multiple IDP simpleSAMLphp authentication
 description = Allows users to authenticate to a remote SAML identity provider (IdP) via a locally configured SimpleSAMLphp service point (SP). This version of the module is able to handle multiple sources (IDP).
 core = 7.x
 configure = admin/config/people/simplesamlphp_auth

--- a/simplesamlphp_auth.pages.inc
+++ b/simplesamlphp_auth.pages.inc
@@ -36,7 +36,7 @@ function simplesamlphp_auth_loginpage($sp = NULL) {
 
   module_load_include('inc', 'simplesamlphp_auth');
   // The user is not logged into Drupal.
-  if ($user->uid == 0) {
+  if ($user->uid == 0) {      
     _simplesaml_auth_login_register();
   }
   else {

--- a/simplesamlphp_auth.pages.inc
+++ b/simplesamlphp_auth.pages.inc
@@ -26,7 +26,7 @@ function simplesamlphp_auth_loginpage($sp = NULL) {
     $simplesamlphp_drupal->load($sp);
   }
   catch (Exception $e) {
-    watchdog_exception('simplesamlphp_auth', $e);
+    watchdog_exception('simplesamlphp_auth', $e, $sp);
   } // End try - catch.
 
   $idp_st = !empty($simplesamlphp_drupal->getAuthSourceAttributes()) ? $simplesamlphp_drupal->getAuthSourceAttributes()->id : $sp;


### PR DESCRIPTION
# Auto-Synchronizing roles of the IDP with the local roles of Drupal.


Light modifications to the module on the eve of modifying the logic of assigning roles to the user that login into drupal. These were done fundamentally to the configuration form  of the IDP and the hook `submit, validate` and to the hook `role_alter` to personalize the logic of assigning roles.

The fallowing step describe de process:

1. A modification to the configuration form of every idp came true from here `admin/config/people/simplesamlphp_auth/idp`. The following field to grab the attribute of the IDP that will be used like identifier of the role of the user was added.
```php
    $form['simplesamlphp_auth_grp_user']['simplesamlphp_auth_roleattr'] = array(
        '#type' => 'textfield',
        '#title' => t('Which attribute from the IDP should be used as role identifier for the user'),
        '#default_value' => isset($attributes['roleattr']) && !empty($attributes['roleattr']) ? $attributes['roleattr'] : '',
        '#description' => t('Example: <i>roles</i><br />If the user attribute is multivalued, the first value will be used.'),
        '#required' => FALSE,
      );
  ```
  
2. The following field to habilitate if it is synchronized or not the roles provided for the IDP with the ones of drupal was added.
```php 
    $form['simplesamlphp_auth_grp_user']['simplesamlphp_auth_syncroles'] = array(
        '#type' => 'checkbox',
        '#title' => t('<strong>Sync roles</strong>'),
        '#default_value' => isset($attributes['syncroles']) && !empty($attributes['syncroles']) ? $attributes['syncroles'] : FALSE,
        '#description' => t('<p>Auto-sync. The role of the Drupal user account will be synchronized with the data provided by the IdP.</p><p>Review the Mapping section.</p>'),
        '#required' => FALSE
      );
```
  
3. The following field was added for mapping the roles of administration of the idp with the ones of drupal, if the `Auto-sync field` was selected.
 
 ```php   
     $form['simplesamlphp_auth_grp_user']['simplesamlphp_auth_role_mapping'] = array(
        '#type' => 'fieldset',
        '#title' => t('ROLE MAPPING')
      );

      $form['simplesamlphp_auth_grp_user']['simplesamlphp_auth_role_mapping']['info'] = array(
        '#markup' => t('<p>The IdP can use it\'s own roles. Set in this section the mapping between IdP and Drupal roles. Accepts multiple valued comma separated.</p>')
      );

      $form['simplesamlphp_auth_grp_user']['simplesamlphp_auth_role_mapping']['simplesamlphp_auth_role_mapping_administrator'] = array(
        '#type' => 'textfield',
        '#title' => t('Administrator'),
        '#default_value' => isset($attributes['rolemappattr']) && !empty($attributes['rolemappattr']) ? $attributes['rolemappattr'] : '',
        '#required' => FALSE,
        '#description' => t('Example: admin,owner,superuser.')
      );
 ``` 
4. Henceforth the hook `simplesamlphp_auth_form_submit` to support the before realized changes was modified.
 ```php 
    /**
     * Implements hook_submit()
     */
    function simplesamlphp_auth_form_submit($form, &$form_state) {
      $data = array(
        'source_name' => $form_state['values']['simplesamlphp_auth_source'],
        'company' => $form_state['values']['simplesamlphp_auth_company_name'],
        'domain' => $form_state['values']['simplesamlphp_auth_domain'],
        'active' => 1
      );
      $attributes = array(
        'username' => $form_state['values']['simplesamlphp_auth_user_name'],
        'unique_id' => $form_state['values']['simplesamlphp_auth_unique_id'],
        'mailattr' => $form_state['values']['simplesamlphp_auth_mailattr'],
    	 //Attributes added to the form.
        'roleattr' => $form_state['values']['simplesamlphp_auth_roleattr'],    
        'syncroles' => $form_state['values']['simplesamlphp_auth_syncroles'],
        'rolemappattr' => $form_state['values']['simplesamlphp_auth_role_mapping_administrator'],
      ); 
 ```
 
 5. Also was modified the hook validate to check that if it is selected `Auto-sync field`, it put on the corresponding values.
```php 
     /**
     * Implements hook_validate() 
     */
    function simplesamlphp_auth_form_validate($form, &$form_state) {
    	if ($form_state['values']['op'] != t('Save')) {
    		.
    		.
    		.
    		
    		if($form_state['values']['simplesamlphp_auth_syncroles'] && empty($form_state['values']['simplesamlphp_auth_role_mapping_administrator'])){
    			form_set_error('simplesamlphp_auth_role_mapping_administrator', t('Auto-sync field is checked, This field can not be empty.'));
    		}
    		
    	  } // end if
    }
```
7. The following function was modified on the eve of, when register the user, updating the information belonging to the roles to which he belongs.
```php 
    function _simplesaml_auth_user_register($authname) {
    		.
    		.
    		.
    		
    		/**
             * Populate roles 
             */
            
            $roles = array();
            // Calling all modules implementing hook_simplesamlphp_auth_user_roles_alter():
            drupal_alter('simplesamlphp_auth_user_roles', $roles);
            // You should implement hook_simplesamlphp_auth_user_roles_alter() in all other modules in which you want to alter $roles
            if (!empty($roles)) {
                    try {
                        $userinfo['roles']= $roles;
                        
                        $user = user_save($user, $userinfo);
                    } catch (Exception $e) {
                        return FALSE;
                    }
            }
    		
    		.
    		.
    		.
```		

8. Another of the changes was in to the hook `simplesamlphp_auth_user_roles_alter` to allow  the modifications of the logic of assigning users roles.
```php 
function hook_simplesamlphp_auth_user_roles_alter(&$roles) {    

    // Get an instance of SimpleSAML_Drupal
    try {

        $simplesamlphp_drupal = SimpleSAML_Drupal::factory();
        $simplesamlphp_auth_as = $simplesamlphp_drupal->getSimpleSAMLAuthSimple();

        // Get SAML attributes
        $attrs = $simplesamlphp_auth_as->getAttributes();
        $simplesamlphp_authsource = $simplesamlphp_drupal->getAuthSourceAttributes();
    } catch (Exception $e) {
        watchdog_exception('simplesamlphp_auth', $e);
    } // end try - catch
   
    $syncroles = $simplesamlphp_drupal->getAttrsFromAssertion($simplesamlphp_authsource->syncroles);


    if ($syncroles) {
        // The roles provided by the IdP.
        $roleMapping = $simplesamlphp_drupal->getAttrsFromAssertion($simplesamlphp_authsource->roleattr);

        if (!empty($roleMapping) && isset($attrs[$roleMapping]) && !empty($attrs[$roleMapping])) {
            $adminsRole = explode(',', $simplesamlphp_drupal->getAttrsFromAssertion($simplesamlphp_authsource->rolemappattr));
            
            $administrator = user_role_load_by_name('administrator');
            $adminWeight = $administrator->rid;
            // Match role names in the saml attributes to local role names.
            $roleWeight = 0;
            foreach ($attrs[$roleMapping] as $samlRole) {
                $samlRole = trim($samlRole);
                if (empty($samlRole)) {
                    break;
                }                
                else if (in_array($samlRole, $adminsRole)) {
                    if ($roleWeight < $adminWeight) {
                        $roleWeight = $adminWeight;
                    }
                    break;
                } else {
                    if ($loadedRole = user_role_load_by_name($samlRole)) {
                        $roles[$loadedRole->rid] = $loadedRole->name;
                    }
                }
            }
            switch ($roleWeight) {
                // case 5:
                //   $roles = array(5 => 'customrole');
                //   break;
                case $adminWeight:
                    $roles[$adminWeight] = 'administrator';
                    break;
                case DRUPAL_AUTHENTICATED_RID: // default value => 2
                default:
                    $roles[DRUPAL_AUTHENTICATED_RID] = 'authenticated user';
                    break;
            }
        }
    }else {        
      $roles[DRUPAL_AUTHENTICATED_RID] = 'authenticated user';    
    }
}
```		
## Issue Submission

When you need additional support or you discover something *strange*, feel free to [Create a new issue](https://github.com/AngelAlvarado/multiple_idp_simplesamlphp/issues/new).

## License and Authors

Authors:  [Erodis Pérez Michel](mailto:eperezm1986@gmail.com)		